### PR TITLE
Fix #2: Switch Windows from `fastpbkdf2` to `ring`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-/target
+.idea/
+.vscode/
+target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aes"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe0133578c0986e1fe3dfcd4af1cc5b2dd6c3dbf534d69916ce16a2701d40ba"
+checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -21,9 +21,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bitflags"
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cfb8"
@@ -88,7 +88,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
- "libc 0.2.135",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -99,7 +99,7 @@ checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
- "libc 0.2.135",
+ "libc 0.2.139",
  "mio",
  "parking_lot",
  "signal-hook",
@@ -154,12 +154,12 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
- "libc 0.2.135",
+ "libc 0.2.139",
  "wasi",
 ]
 
@@ -186,9 +186,9 @@ checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "lock_api"
@@ -211,11 +211,11 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
- "libc 0.2.135",
+ "libc 0.2.139",
  "log",
  "wasi",
  "windows-sys",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "ncr-crypto"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes",
  "base64",
@@ -254,12 +254,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
- "libc 0.2.135",
+ "libc 0.2.139",
  "redox_syscall",
  "smallvec",
  "windows-sys",
@@ -267,18 +267,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -304,7 +304,7 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
- "libc 0.2.135",
+ "libc 0.2.139",
  "signal-hook-registry",
 ]
 
@@ -314,7 +314,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
- "libc 0.2.135",
+ "libc 0.2.139",
  "mio",
  "signal-hook",
 ]
@@ -325,7 +325,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
- "libc 0.2.135",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -336,24 +336,24 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "tqdm"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c8517ad60c25ab6bc67d6d838fea1b4bddad5ffed4be85e7f8a47b9feba3"
+checksum = "072a87dc8f40f8bdd6935413dc16140e9dd5100cee28fee326fe5e09a579c5ae"
 dependencies = [
  "crossterm",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "version_check"
@@ -391,43 +391,57 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
+ "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.36.1"
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,10 +52,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
 name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+
+[[package]]
+name = "cc"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfb8"
@@ -88,7 +100,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
- "libc 0.2.139",
+ "libc",
 ]
 
 [[package]]
@@ -99,7 +111,7 @@ checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
- "libc 0.2.139",
+ "libc",
  "mio",
  "parking_lot",
  "signal-hook",
@@ -127,22 +139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastpbkdf2"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25415467e1580ab15d51915f1be91b12f4bdce14e2184d123de6bfbea8ca186e"
-dependencies = [
- "gcc",
- "libc 0.1.12",
-]
-
-[[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-
-[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -159,7 +155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
- "libc 0.2.139",
+ "libc",
  "wasi",
 ]
 
@@ -179,10 +175,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2007b51b83dc078bc08617dab8f41d7abd61bce0e7732f79e1d01219bf0add80"
 
 [[package]]
-name = "libc"
-version = "0.1.12"
+name = "js-sys"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -215,7 +214,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
- "libc 0.2.139",
+ "libc",
  "log",
  "wasi",
  "windows-sys",
@@ -230,9 +229,9 @@ dependencies = [
  "bruteforce",
  "bytes",
  "cfb8",
- "fastpbkdf2",
  "getrandom",
  "java-rand",
+ "ring",
  "tqdm",
 ]
 
@@ -241,6 +240,12 @@ name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
+name = "once_cell"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "parking_lot"
@@ -259,7 +264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
- "libc 0.2.139",
+ "libc",
  "redox_syscall",
  "smallvec",
  "windows-sys",
@@ -293,6 +298,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,7 +324,7 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
 dependencies = [
- "libc 0.2.139",
+ "libc",
  "signal-hook-registry",
 ]
 
@@ -314,7 +334,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
- "libc 0.2.139",
+ "libc",
  "mio",
  "signal-hook",
 ]
@@ -325,7 +345,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
- "libc 0.2.139",
+ "libc",
 ]
 
 [[package]]
@@ -333,6 +353,23 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "syn"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "tqdm"
@@ -356,6 +393,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +409,70 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,42 +14,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bruteforce"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc553dba664ca53a0fa77babe08597539715949bc24aa39519ddecfd415a9909"
-dependencies = [
- "bruteforce-macros",
- "no-std-compat",
-]
-
-[[package]]
-name = "bruteforce-macros"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f06f26040d579cc4017ced69bcd47a63f4b1f076f94c7bbae97df359ed61adfd"
-dependencies = [
- "no-std-compat",
- "quote",
-]
 
 [[package]]
 name = "bumpalo"
@@ -101,31 +69,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crossterm"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae1b35a484aa10e07fe0638d02301c5ad24de82d310ccbd2f3693da5f09bf1c"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -190,16 +133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
-name = "lock_api"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,66 +142,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys",
-]
-
-[[package]]
 name = "ncr-crypto"
 version = "0.2.0"
 dependencies = [
  "aes",
  "base64",
- "bruteforce",
  "bytes",
  "cfb8",
  "getrandom",
  "java-rand",
  "ring",
- "tqdm",
 ]
-
-[[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
 name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-sys",
-]
 
 [[package]]
 name = "proc-macro2"
@@ -289,15 +179,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,48 +192,6 @@ dependencies = [
  "web-sys",
  "winapi",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "signal-hook"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253b5e89e2698464fc26b545c9edceb338e18a89effeeecfea192c3025be29d"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "spin"
@@ -369,15 +208,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tqdm"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "072a87dc8f40f8bdd6935413dc16140e9dd5100cee28fee326fe5e09a579c5ae"
-dependencies = [
- "crossterm",
 ]
 
 [[package]]
@@ -495,60 +325,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
- "libc",
+ "libc 0.2.139",
 ]
 
 [[package]]
@@ -80,6 +80,22 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "fastpbkdf2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25415467e1580ab15d51915f1be91b12f4bdce14e2184d123de6bfbea8ca186e"
+dependencies = [
+ "gcc",
+ "libc 0.1.12",
+]
+
+[[package]]
+name = "gcc"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
@@ -98,7 +114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
- "libc",
+ "libc 0.2.139",
  "wasi",
 ]
 
@@ -128,6 +144,12 @@ dependencies = [
 
 [[package]]
 name = "libc"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
+
+[[package]]
+name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
@@ -149,6 +171,7 @@ dependencies = [
  "base64",
  "bytes",
  "cfb8",
+ "fastpbkdf2",
  "getrandom",
  "java-rand",
  "ring",
@@ -185,7 +208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
- "libc",
+ "libc 0.2.139",
  "once_cell",
  "spin",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,18 @@ repository = "https://github.com/JorianWoltjer/ncr-crypto"
 aes = "0.8"
 bytes = "1"
 cfb8 = "0.8"
+fastpbkdf2 = { version = "0.1.0", optional = true }
 getrandom = "0.2"
 java-rand = "0.2"
-ring = "0.16.20"
+ring = { version = "0.16.20", optional = true }
 
 [dev-dependencies]
 base64 = "0.21.0"
+
+[features]
+default = ["fastpbkdf2"]
+fastpbkdf2 = ["dep:fastpbkdf2"]
+ring = ["dep:ring"]
+
+[target.'cfg(windows)'.features]
+default = ["ring"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,14 @@ repository = "https://github.com/JorianWoltjer/ncr-crypto"
 aes = "0.8"
 bytes = "1"
 cfb8 = "0.8"
-fastpbkdf2 = { version = "0.1.0", optional = true }
 getrandom = "0.2"
 java-rand = "0.2"
-ring = { version = "0.16.20", optional = true }
+
+[target.'cfg(not(windows))'.dependencies]
+fastpbkdf2 = "0.1.0"
+
+[target.'cfg(windows)'.dependencies]
+ring = "0.16.20"
 
 [dev-dependencies]
 base64 = "0.21.0"
-
-[features]
-default = ["fastpbkdf2"]
-fastpbkdf2 = ["dep:fastpbkdf2"]
-ring = ["dep:ring"]
-
-[target.'cfg(windows)'.features]
-default = ["ring"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,19 +2,21 @@
 name = "ncr-crypto"
 description = "A library for the cryptography used in the Minecraft No-Chat-Reports Mod"
 license = "MIT"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 repository = "https://github.com/JorianWoltjer/ncr-crypto"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+aes = "0.8"
+bruteforce = "0.2"
 bytes = "1"
+cfb8 = "0.8"
+fastpbkdf2 = "0.1"
 getrandom = "0.2"
 java-rand = "0.2"
-fastpbkdf2 = "0.1"
-base64 = "0.13"
-aes = "0.8"
-cfb8 = "0.8"
 tqdm = "0.4"
-bruteforce = "0.2"
+
+[dev-dependencies]
+base64 = "0.21.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ aes = "0.8"
 bruteforce = "0.2"
 bytes = "1"
 cfb8 = "0.8"
-fastpbkdf2 = "0.1"
 getrandom = "0.2"
 java-rand = "0.2"
+ring = "0.16.20"
 tqdm = "0.4"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,11 @@ repository = "https://github.com/JorianWoltjer/ncr-crypto"
 
 [dependencies]
 aes = "0.8"
-bruteforce = "0.2"
 bytes = "1"
 cfb8 = "0.8"
 getrandom = "0.2"
 java-rand = "0.2"
 ring = "0.16.20"
-tqdm = "0.4"
 
 [dev-dependencies]
 base64 = "0.21.0"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The cryptography used to generate passwords and encrypted messages
 exactly as the [No Chat Reports](https://github.com/Aizistral-Studios/No-Chat-Reports) Mod for Minecraft does.
 
-# Example
+## Example
 
 ```Rust
 use ncr_encryption::{decrypt_with_passphrase, decode_and_verify};
@@ -18,7 +18,7 @@ let decoded = decode_and_verify(&decrypted);
 assert_eq!(decoded, Ok("#%Hello, world!"))
 ```
 
-# How it works
+## How it works
 
 From reading the Source Code on Github it becomes clear how the mod does encryption:
 
@@ -36,3 +36,16 @@ Decrypting then is very similar, just in reverse:
 2. Get the nonce from the message and generate the IV again with it
 2. Generate the hash from the secret passphrase again, and use it as the key for the AES encryption
 3. If the decrypted message starts with `"#%"`, the rest is printed decrypted in the chat
+
+## Windows Performance
+By default `fastpbkdf2` doesn't compile for Windows, [see here](https://github.com/JorianWoltjer/ncr-crypto/issues/2)  
+This crate will use `ring` by default on Windows which is slower than `fastpbkdf2`, [see here](https://github.com/JorianWoltjer/ncr-crypto/pull/3#issuecomment-1379112983)  
+If you're concerned with performance it is recommended to use the Windows Subsystem for Linux.  
+You may manually switch between the two using the `fastpbkdf2` and `ring` features.
+
+```toml
+[ncr-crypto]
+git = "https://github.com/JorianWoltjer/ncr-crypto.git"
+default-features = false
+features = ["ring"]
+```

--- a/README.md
+++ b/README.md
@@ -40,12 +40,4 @@ Decrypting then is very similar, just in reverse:
 ## Windows Performance
 By default `fastpbkdf2` doesn't compile for Windows, [see here](https://github.com/JorianWoltjer/ncr-crypto/issues/2)  
 This crate will use `ring` by default on Windows which is slower than `fastpbkdf2`, [see here](https://github.com/JorianWoltjer/ncr-crypto/pull/3#issuecomment-1379112983)  
-If you're concerned with performance it is recommended to use the Windows Subsystem for Linux.  
-You may manually switch between the two using the `fastpbkdf2` and `ring` features.
-
-```toml
-[ncr-crypto]
-git = "https://github.com/JorianWoltjer/ncr-crypto.git"
-default-features = false
-features = ["ring"]
-```
+If you're concerned with performance it is recommended to use the Windows Subsystem for Linux.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,113 +1,113 @@
 //! # No Chat Reports (NCR) Crypto
-//! 
+//!
 //! The cryptography used to generate passwords and encrypted messages
 //! exactly as the [No Chat Reports](https://github.com/Aizistral-Studios/No-Chat-Reports) Mod for Minecraft does.
-//! 
+//!
 //! # Examples
-//! 
+//!
 //! ```
 //! use ncr_encryption::{decrypt_with_passphrase, decode_and_verify};
-//! 
+//!
 //! let passphrase = b"secret";  // Setting in NCR
 //! // "Hello, world!" sent as a message in chat:
 //! let ciphertext = base64::decode("q2JCS/M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
-//! 
+//!
 //! let decrypted = decrypt_with_passphrase(&ciphertext, passphrase);
 //! let decoded = decode_and_verify(&decrypted);
-//! 
+//!
 //! assert_eq!(decoded, Ok("#%Hello, world!"))
 //! ```
-//! 
+//!
 //! # How it works
-//! 
+//!
 //! From reading the Source Code on Github it becomes clear how the mod does encryption:
-//! 
+//!
 //! 1. You set a passphrase like "secret" in the UI
-//! 2. The mod uses `PBKDF2WithHmacSHA1` with a hardcoded salt and 65536 iterations to make your passphrase 
+//! 2. The mod uses `PBKDF2WithHmacSHA1` with a hardcoded salt and 65536 iterations to make your passphrase
 //! into a hash of 16 bytes. This process takes the longest
 //! 3. An Initialization Vector (IV) is generated from a random nonce value, and used in the encryption that follows
 //! 4. The new hash becomes the key used for encrypting any messages you send with `AES-CFB8` encryption
-//! 5. The ciphertext that comes from this encryption is appended to the nonce that was generated, and the final message 
+//! 5. The ciphertext that comes from this encryption is appended to the nonce that was generated, and the final message
 //! that is sent in Base64 encoding through the chat (note: `"#%"` is added as a prefix to the message before encrypting)
-//! 
+//!
 //! Decrypting then is very similar, just in reverse:
-//! 
+//!
 //! 1. Decode the message from Base64 into raw bytes
 //! 2. Get the nonce from the message and generate the IV again with it
 //! 2. Generate the hash from the secret passphrase again, and use it as the key for the AES encryption
 //! 3. If the decrypted message starts with `"#%"`, the rest is printed decrypted in the chat
 
-use std::{io::{BufReader, Read}, str::{from_utf8}, fmt::Display};
+use std::{
+    fmt::Display,
+    io::{BufReader, Read},
+    str::from_utf8,
+};
 
-use fastpbkdf2::pbkdf2_hmac_sha1;
 use aes::cipher::{AsyncStreamCipher, KeyIvInit};
-use bytes::{Bytes, BytesMut, Buf, BufMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use fastpbkdf2::pbkdf2_hmac_sha1;
 
 type Aes128Cfb8Dec = cfb8::Decryptor<aes::Aes128>;
 type Aes128Cfb8Enc = cfb8::Encryptor<aes::Aes128>;
 
-/// Contant salt for all passphrases ([source](https://github.com/Aizistral-Studios/No-Chat-Reports/blob/c2c60a03544952fe608bd65163cc0b2658e3c032/src/main/java/com/aizistral/nochatreports/encryption/AESEncryption.java#L57-L58))
-/// 
+/// Content salt for all passphrases ([source](https://github.com/Aizistral-Studios/No-Chat-Reports/blob/c2c60a03544952fe608bd65163cc0b2658e3c032/src/main/java/com/aizistral/nochatreports/encryption/AESEncryption.java#L57-L58))
+///
 /// Generated as follows:
-/// 
+///
 /// ```
 /// let mut salt = [0; 16];
 /// java_rand::Random::new(1738389128127)
 ///     .next_bytes(&mut salt);
-/// 
+///
 /// assert_eq!(salt, [45, 72, 24, 73, 11, 12, 10, 149, 250, 165, 68, 71, 1, 217, 153, 119]);
 /// ```
-pub const SALT: [u8; 16] = [45, 72, 24, 73, 11, 12, 10, 149, 250, 165, 68, 71, 1, 217, 153, 119];
-
+pub const SALT: [u8; 16] = [
+    45, 72, 24, 73, 11, 12, 10, 149, 250, 165, 68, 71, 1, 217, 153, 119,
+];
 
 /// Generate a key from a passphrase
-/// 
+///
 /// Use `PBKDF2WithHmacSHA1` with a hardcoded salt and 65536 iterations to hash a passphrase into a 16-byte key
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use ncr_encryption::generate_key;
-/// 
+///
 /// let passphrase = b"secret";
-/// 
+///
 /// let key = generate_key(passphrase);
-/// 
+///
 /// assert_eq!(base64::encode(key), "474esvGYVuN83HpxbK1uFQ==");  // Can be seen in the NCR UI when typing the passphrase
 /// ```
 pub fn generate_key(passphrase: &[u8]) -> [u8; 16] {
     let mut key = [0; 16];
-    pbkdf2_hmac_sha1(
-        passphrase, 
-        &SALT, 
-        65536, 
-        &mut key,
-    );
+    pbkdf2_hmac_sha1(passphrase, &SALT, 65536, &mut key);
 
     key
 }
 
 /// Encrypt a plaintext message with a given key
-/// 
-/// > **Warning**: This function does **not** append `"#%"` to the message before encrypting. NCR automatically does this when sending a message, 
+///
+/// > **Warning**: This function does **not** append `"#%"` to the message before encrypting. NCR automatically does this when sending a message,
 /// > so add it if you're planning to send a real message that NCR should recognize
-/// 
-/// NCR uses AES-CFB8 for encryption, with a 16-byte key. Generate a key from [`generate_key()`] using a passphrase, or 
+///
+/// NCR uses AES-CFB8 for encryption, with a 16-byte key. Generate a key from [`generate_key()`] using a passphrase, or
 /// provide the raw bytes to this function. You can also use [`encrypt_with_passphrase()`] as a shorthand for doing both of these things
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use ncr_encryption::{encrypt, decrypt};
-/// 
+///
 /// let key = base64::decode("blfrngArk3chG6wzncOZ5A==").unwrap();  // Default key
 /// let key = key.try_into().unwrap();
 /// let plaintext = b"#%Hello, world!";
-/// 
+///
 /// let encrypted = encrypt(plaintext, &key);
 /// // Here `encrypted` is something random like [240, 28, 167, ..., 237, 3, 89]
 /// let decrypted = decrypt(&encrypted, &key);
-/// 
+///
 /// assert_eq!(decrypted, plaintext);
 /// ```
 pub fn encrypt(plaintext: &[u8], key: &[u8; 16]) -> Vec<u8> {
@@ -116,37 +116,36 @@ pub fn encrypt(plaintext: &[u8], key: &[u8; 16]) -> Vec<u8> {
     let mut plaintext = Vec::from(plaintext);
 
     let mut nonce = [0; 8];
-    getrandom::getrandom(&mut nonce).unwrap();  // Actually uses java.security.SecureRandom, but for generating our nonce this doesn't matter
+    getrandom::getrandom(&mut nonce).unwrap(); // Actually uses java.security.SecureRandom, but for generating our nonce this doesn't matter
     let nonce = Bytes::from(Vec::from(nonce)).get_u64();
 
     let mut iv = [0; 16];
     java_rand::Random::new(nonce).next_bytes(&mut iv);
-    
-    Aes128Cfb8Enc::new(key.into(), &iv.into())
-        .encrypt(&mut plaintext);
+
+    Aes128Cfb8Enc::new(key.into(), &iv.into()).encrypt(&mut plaintext);
 
     let mut ciphertext = BytesMut::with_capacity(8 + plaintext.len());
     ciphertext.put(Bytes::from(Vec::from(nonce.to_be_bytes())));
-    ciphertext.put(Bytes::from(plaintext));  // `plaintext` is encrypted at this point
+    ciphertext.put(Bytes::from(plaintext)); // `plaintext` is encrypted at this point
 
     ciphertext.to_vec()
 }
 
 /// Decrypt a ciphertext message with a given key
-/// 
-/// NCR uses AES-CFB8 for encryption, with a 16-byte key. Generate a key from [`generate_key()`] using a passphrase, or 
+///
+/// NCR uses AES-CFB8 for encryption, with a 16-byte key. Generate a key from [`generate_key()`] using a passphrase, or
 /// provide the raw bytes to this function. You can also use [`decrypt_with_passphrase()`] as a shorthand for doing both of these things
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use ncr_encryption::decrypt;
-/// 
+///
 /// let key = base64::decode("blfrngArk3chG6wzncOZ5A==").unwrap();  // Default key
 /// let ciphertext = base64::decode("NuhaeyIn3WJDHY/W0X++EJKON32pDAA=").unwrap();
-/// 
+///
 /// let decrypted = decrypt(&ciphertext, &key.try_into().unwrap());
-/// 
+///
 /// assert_eq!(std::str::from_utf8(&decrypted).unwrap(), "#%Hello, world!");
 /// ```
 pub fn decrypt(ciphertext: &[u8], key: &[u8; 16]) -> Vec<u8> {
@@ -159,32 +158,30 @@ pub fn decrypt(ciphertext: &[u8], key: &[u8; 16]) -> Vec<u8> {
     let mut encrypted = Vec::new();
     buf_reader.read_to_end(&mut encrypted).unwrap();
 
-    
     let mut iv = [0; 16];
     java_rand::Random::new(nonce).next_bytes(&mut iv);
 
-    Aes128Cfb8Dec::new(key.into(), &iv.into())
-        .decrypt(&mut encrypted);
+    Aes128Cfb8Dec::new(key.into(), &iv.into()).decrypt(&mut encrypted);
 
     encrypted.to_vec()
 }
 
 /// Encrypt a ciphertext message with a given passphrase
-/// 
+///
 /// Shorthand for [`generate_key()`] and then [`encrypt()`]
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
-///use ncr_encryption::{encrypt_with_passphrase, decrypt_with_passphrase};
-/// 
+/// use ncr_encryption::{encrypt_with_passphrase, decrypt_with_passphrase};
+///
 /// let passphrase = b"secret";
 /// let plaintext = b"#%Hello, world!";
-/// 
+///
 /// let encrypted = encrypt_with_passphrase(plaintext, passphrase);
 /// // Here `encrypted` is something random like [240, 28, 167, ..., 237, 3, 89]
 /// let decrypted = decrypt_with_passphrase(&encrypted, passphrase);
-/// 
+///
 /// assert_eq!(decrypted, plaintext);
 /// ```
 pub fn encrypt_with_passphrase(plaintext: &[u8], passphrase: &[u8]) -> Vec<u8> {
@@ -193,19 +190,19 @@ pub fn encrypt_with_passphrase(plaintext: &[u8], passphrase: &[u8]) -> Vec<u8> {
 }
 
 /// Decrypt a ciphertext message with a given passphrase
-/// 
+///
 /// Shorthand for [`generate_key()`] and then [`decrypt()`]
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use ncr_encryption::decrypt_with_passphrase;
-/// 
+///
 /// let passphrase = b"secret";
 /// let ciphertext = base64::decode("q2JCS/M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
-/// 
+///
 /// let decrypted = decrypt_with_passphrase(&ciphertext, passphrase);
-/// 
+///
 /// assert_eq!(std::str::from_utf8(&decrypted).unwrap(), "#%Hello, world!");
 /// ```
 pub fn decrypt_with_passphrase(ciphertext: &[u8], passphrase: &[u8]) -> Vec<u8> {
@@ -223,51 +220,52 @@ impl Display for FormatError {
 }
 
 /// Verify if a message could be correctly decrypted
-/// 
+///
 /// Decrypted message from NCR are always prefixed with "#%", and contain valid UTF8. This function verifies both of these things
 /// and returns a Result containing the decoded `&str` or a `FormatError` in case it is not valid
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// use ncr_encryption::{decode_and_verify, decrypt_with_passphrase};
-/// 
+///
 /// let passphrase = b"secret";
 /// let ciphertext = base64::decode("q2JCS/M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
-/// 
+///
 /// let decrypted = decrypt_with_passphrase(&ciphertext, passphrase);
 /// let decoded = decode_and_verify(&decrypted);
-/// 
+///
 /// assert_eq!(decoded, Ok("#%Hello, world!"));
 /// ```
-/// 
+///
 /// ```
 /// use ncr_encryption::{decode_and_verify, decrypt_with_passphrase, FormatError};
-/// 
+///
 /// let passphrase = b"wrong";  // Should be "secret"
 /// let ciphertext = base64::decode("q2JCS/M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
-/// 
+///
 /// let decrypted = decrypt_with_passphrase(&ciphertext, passphrase);
 /// let decoded = decode_and_verify(&decrypted);
-/// 
+///
 /// assert_eq!(decoded, Err(FormatError));
 /// ```
-/// 
+///
 /// ```
 /// use ncr_encryption::{decode_and_verify, FormatError};
-/// 
+///
 /// let bytes = b"Hello, world!";  // Without "#%" prefix
 /// let decoded = decode_and_verify(bytes);
-/// 
+///
 /// assert_eq!(decoded, Err(FormatError));
 /// ```
 pub fn decode_and_verify(bytes: &[u8]) -> Result<&str, FormatError> {
-    if bytes.len() < 2 || bytes[..2] != [35, 37] {  // "#%"
-        return Err(FormatError)
+    if bytes.len() < 2 || bytes[..2] != [35, 37] {
+        // "#%"
+        return Err(FormatError);
     }
 
     match from_utf8(bytes) {
         Ok(decoded) => Ok(decoded),
-        Err(_) => Err(FormatError)
+        Err(_) => Err(FormatError),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,11 +40,12 @@
 //! 2. Generate the hash from the secret passphrase again, and use it as the key for the AES encryption
 //! 3. If the decrypted message starts with `"#%"`, the rest is printed decrypted in the chat
 
-use std::num::NonZeroU32;
-use std::ptr::invalid;
 use std::{
+    error::Error,
     fmt::Display,
     io::{BufReader, Read},
+    num::NonZeroU32,
+    ptr::invalid,
     str::from_utf8,
 };
 
@@ -237,6 +238,7 @@ pub fn decrypt_with_passphrase(ciphertext: &[u8], passphrase: &[u8]) -> Vec<u8> 
 #[derive(Debug, Clone, PartialEq)]
 pub struct FormatError;
 
+impl Error for FormatError {}
 impl Display for FormatError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "string did not start with '#%' or is invalid UTF8")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,11 @@ use std::{
 
 use aes::cipher::{AsyncStreamCipher, KeyIvInit};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+#[cfg(feature = "fastpbkdf2")]
+use fastpbkdf2::pbkdf2_hmac_sha1;
+#[cfg(feature = "ring")]
 use ring::pbkdf2;
+#[cfg(feature = "ring")]
 use ring::pbkdf2::PBKDF2_HMAC_SHA1;
 
 type Aes128Cfb8Dec = cfb8::Decryptor<aes::Aes128>;
@@ -91,6 +95,11 @@ pub const SALT: [u8; 16] = [
 /// ```
 pub fn generate_key(passphrase: &[u8]) -> [u8; 16] {
     let mut key = [0; 16];
+
+    #[cfg(feature = "fastpbkdf2")]
+    pbkdf2_hmac_sha1(passphrase, &SALT, 65536, &mut key);
+
+    #[cfg(feature = "ring")]
     pbkdf2::derive(
         PBKDF2_HMAC_SHA1,
         NonZeroU32::new(65536).unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@ use std::{
     fmt::Display,
     io::{BufReader, Read},
     num::NonZeroU32,
-    ptr::invalid,
     str::from_utf8,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,13 @@
 //! # Examples
 //!
 //! ```
+//! use base64::{alphabet::STANDARD, engine::{GeneralPurpose, GeneralPurposeConfig}, Engine};
 //! use ncr_encryption::{decrypt_with_passphrase, decode_and_verify};
 //!
 //! let passphrase = b"secret";  // Setting in NCR
 //! // "Hello, world!" sent as a message in chat:
-//! let ciphertext = base64::decode("q2JCS/M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
+//! let b64 = GeneralPurpose::new(&STANDARD, GeneralPurposeConfig::new());
+//! let ciphertext = b64::decode("q2JCS/M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
 //!
 //! let decrypted = decrypt_with_passphrase(&ciphertext, passphrase);
 //! let decoded = decode_and_verify(&decrypted);
@@ -72,13 +74,15 @@ pub const SALT: [u8; 16] = [
 /// # Examples
 ///
 /// ```
+/// use base64::{alphabet::STANDARD, engine::{GeneralPurpose, GeneralPurposeConfig}, Engine};
 /// use ncr_encryption::generate_key;
 ///
 /// let passphrase = b"secret";
 ///
 /// let key = generate_key(passphrase);
+/// let b64 = GeneralPurpose::new(&STANDARD, GeneralPurposeConfig::new());
 ///
-/// assert_eq!(base64::encode(key), "474esvGYVuN83HpxbK1uFQ==");  // Can be seen in the NCR UI when typing the passphrase
+/// assert_eq!(b64::encode(key), "474esvGYVuN83HpxbK1uFQ==");  // Can be seen in the NCR UI when typing the passphrase
 /// ```
 pub fn generate_key(passphrase: &[u8]) -> [u8; 16] {
     let mut key = [0; 16];
@@ -98,9 +102,11 @@ pub fn generate_key(passphrase: &[u8]) -> [u8; 16] {
 /// # Examples
 ///
 /// ```
+/// use base64::{alphabet::STANDARD, engine::{GeneralPurpose, GeneralPurposeConfig}, Engine};
 /// use ncr_encryption::{encrypt, decrypt};
 ///
-/// let key = base64::decode("blfrngArk3chG6wzncOZ5A==").unwrap();  // Default key
+/// let b64 = GeneralPurpose::new(&STANDARD, GeneralPurposeConfig::new());
+/// let key = b64::decode("blfrngArk3chG6wzncOZ5A==").unwrap();  // Default key
 /// let key = key.try_into().unwrap();
 /// let plaintext = b"#%Hello, world!";
 ///
@@ -139,10 +145,12 @@ pub fn encrypt(plaintext: &[u8], key: &[u8; 16]) -> Vec<u8> {
 /// # Examples
 ///
 /// ```
+/// use base64::{alphabet::STANDARD, engine::{GeneralPurpose, GeneralPurposeConfig}, Engine};
 /// use ncr_encryption::decrypt;
 ///
-/// let key = base64::decode("blfrngArk3chG6wzncOZ5A==").unwrap();  // Default key
-/// let ciphertext = base64::decode("NuhaeyIn3WJDHY/W0X++EJKON32pDAA=").unwrap();
+/// let b64 = GeneralPurpose::new(&STANDARD, GeneralPurposeConfig::new());
+/// let key = b64::decode("blfrngArk3chG6wzncOZ5A==").unwrap();  // Default key
+/// let ciphertext = b64::decode("NuhaeyIn3WJDHY/W0X++EJKON32pDAA=").unwrap();
 ///
 /// let decrypted = decrypt(&ciphertext, &key.try_into().unwrap());
 ///
@@ -196,10 +204,12 @@ pub fn encrypt_with_passphrase(plaintext: &[u8], passphrase: &[u8]) -> Vec<u8> {
 /// # Examples
 ///
 /// ```
+/// use base64::{alphabet::STANDARD, engine::{GeneralPurpose, GeneralPurposeConfig}, Engine};
 /// use ncr_encryption::decrypt_with_passphrase;
 ///
+/// let b64 = GeneralPurpose::new(&STANDARD, GeneralPurposeConfig::new());
 /// let passphrase = b"secret";
-/// let ciphertext = base64::decode("q2JCS/M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
+/// let ciphertext = b64::decode("q2JCS/M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
 ///
 /// let decrypted = decrypt_with_passphrase(&ciphertext, passphrase);
 ///
@@ -227,10 +237,12 @@ impl Display for FormatError {
 /// # Examples
 ///
 /// ```
+/// use base64::{alphabet::STANDARD, engine::{GeneralPurpose, GeneralPurposeConfig}, Engine};
 /// use ncr_encryption::{decode_and_verify, decrypt_with_passphrase};
 ///
+/// let b64 = GeneralPurpose::new(&STANDARD, GeneralPurposeConfig::new());
 /// let passphrase = b"secret";
-/// let ciphertext = base64::decode("q2JCS/M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
+/// let ciphertext = b64::decode("q2JCS/M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
 ///
 /// let decrypted = decrypt_with_passphrase(&ciphertext, passphrase);
 /// let decoded = decode_and_verify(&decrypted);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! // "Hello, world!" sent as a message in chat:
 //! let alphabet = Alphabet::new("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+\\").unwrap();
 //! let b64 = GeneralPurpose::new(&alphabet, GeneralPurposeConfig::new());
-//! let ciphertext = b64.decode("q2JCS/M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
+//! let ciphertext = b64.decode("q2JCS\\M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
 //!
 //! let decrypted = decrypt_with_passphrase(&ciphertext, passphrase);
 //! let decoded = decode_and_verify(&decrypted);
@@ -175,7 +175,7 @@ pub fn encrypt(plaintext: &[u8], key: &[u8; 16]) -> Vec<u8> {
 /// let alphabet = Alphabet::new("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+\\").unwrap();
 /// let b64 = GeneralPurpose::new(&alphabet, GeneralPurposeConfig::new());
 /// let key = b64.decode("blfrngArk3chG6wzncOZ5A==").unwrap();  // Default key
-/// let ciphertext = b64.decode("NuhaeyIn3WJDHY/W0X++EJKON32pDAA=").unwrap();
+/// let ciphertext = b64.decode("NuhaeyIn3WJDHY\\W0X++EJKON32pDAA=").unwrap();
 ///
 /// let decrypted = decrypt(&ciphertext, &key.try_into().unwrap());
 ///
@@ -235,7 +235,7 @@ pub fn encrypt_with_passphrase(plaintext: &[u8], passphrase: &[u8]) -> Vec<u8> {
 /// let alphabet = Alphabet::new("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+\\").unwrap();
 /// let b64 = GeneralPurpose::new(&alphabet, GeneralPurposeConfig::new());
 /// let passphrase = b"secret";
-/// let ciphertext = b64.decode("q2JCS/M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
+/// let ciphertext = b64.decode("q2JCS\\M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
 ///
 /// let decrypted = decrypt_with_passphrase(&ciphertext, passphrase);
 ///
@@ -270,7 +270,7 @@ impl Display for FormatError {
 /// let alphabet = Alphabet::new("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+\\").unwrap();
 /// let b64 = GeneralPurpose::new(&alphabet, GeneralPurposeConfig::new());
 /// let passphrase = b"secret";
-/// let ciphertext = b64.decode("q2JCS/M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
+/// let ciphertext = b64.decode("q2JCS\\M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
 ///
 /// let decrypted = decrypt_with_passphrase(&ciphertext, passphrase);
 /// let decoded = decode_and_verify(&decrypted);
@@ -285,7 +285,7 @@ impl Display for FormatError {
 /// let alphabet = Alphabet::new("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+\\").unwrap();
 /// let b64 = GeneralPurpose::new(&alphabet, GeneralPurposeConfig::new());
 /// let passphrase = b"wrong";  // Should be "secret"
-/// let ciphertext = b64.decode("q2JCS/M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
+/// let ciphertext = b64.decode("q2JCS\\M3yMnz+MtXDn4dd6xyqN94Dao=").unwrap();
 ///
 /// let decrypted = decrypt_with_passphrase(&ciphertext, passphrase);
 /// let decoded = decode_and_verify(&decrypted);


### PR DESCRIPTION
This pull request fixes #2:
- Formats the code using standard `rustfmt`.
- Switches from `fastpbkdf2` to `ring` to fix compiling on Windows.
- Makes `base64` a dev-dependency as it's only used in examples.
- Updates `base64` and examples,
Users are welcome to use the simpler deprecated functions or older versions of `base64` but examples should be up to date.

EDIT: If you chose to merge this, I would recommend a Squash merge, I made a lot of commits.